### PR TITLE
change hard Minecraft dependency & change license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bin/
 
 # fabric
 
+minecraft
 run/
 src/main/resources/assets/atbyw/textures/block/ref/
 src/main/resources/assets/atbyw/models/block/statues/bbmodels/

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,11 +8,11 @@
     "Azagwen"
   ],
   "contact": {
-    "homepage": "https://www.curseforge.com/minecraft/mc-mods/all-the-blocks-you-want",
+    "homepage": "https://www.curseforge.com/minecraft/mc-mods/atbyw",
     "sources": "https://github.com/Azagwen/ATBYW"
   },
 
-  "license": "CC0",
+  "license": "MIT",
   "icon": "assets/atbyw/icon.png",
 
   "environment": "*",
@@ -35,7 +35,7 @@
   "depends": {
     "fabricloader": ">=0.10.8",
     "fabric": "*",
-    "minecraft": "1.16.5"
+    "minecraft": "~1.16.2"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
I tested your mod from 1.16.1 to 1.16.5 and had no problems from 1.16.2 upwards. Therefore it makes sense to change the required minecraft version to ~1.16.2. 

I think 1.16.1 didn't work because some blocks have a luminance value (which 1.16.1 fabric doesn't support?)

Also changed license to MIT and a shorter Homepage link.